### PR TITLE
Remove inner class in mixin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ trim_trailing_whitespace = true
 [*.{bat,ini}]
 end_of_line = crlf
 
-[*.{dtd,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
+[*.{dtd,json,info,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
 indent_size = 2
+
+[*.lang]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+* text eol=lf
+
+*.[jJ][aA][rR]          binary
+
+*.[pP][nN][gG]          binary
+*.[jJ][pP][gG]          binary
+*.[jJ][pP][eE][gG]      binary
+*.[gG][iI][fF]          binary
+*.[tT][iI][fF]          binary
+*.[tT][iI][fF][fF]      binary
+*.[iI][cC][oO]          binary
+*.[sS][vV][gG]          text
+*.[eE][pP][sS]          binary
+*.[xX][cC][fF]          binary
+
+*.[kK][aA][rR]          binary
+*.[mM]4[aA]             binary
+*.[mM][iI][dD]          binary
+*.[mM][iI][dD][iI]      binary
+*.[mM][pP]3             binary
+*.[oO][gG][gG]          binary
+*.[rR][aA]              binary
+
+*.7[zZ]                 binary
+*.[gG][zZ]              binary
+*.[tT][aA][rR]          binary
+*.[tT][gG][zZ]          binary
+*.[zZ][iI][pP]          binary
+
+*.[tT][cC][nN]          binary
+*.[sS][oO]              binary
+*.[dD][lL][lL]          binary
+*.[dD][yY][lL][iI][bB]  binary
+*.[pP][sS][dD]          binary
+*.[tT][tT][fF]          binary
+*.[oO][tT][fF]          binary
+
+*.[pP][aA][tT][cC][hH]  -text
+
+*.[bB][aA][tT]          text eol=crlf
+*.[cC][mM][dD]          text eol=crlf
+*.[pP][sS]1             text eol=crlf
+
+*[aA][uU][tT][oO][gG][eE][nN][eE][rR][aA][tT][eE][dD]* binary

--- a/.github/scripts/update_version
+++ b/.github/scripts/update_version
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if ! git diff --name-only HEAD HEAD~1 | grep -qF 'build.gradle'; then
+  new_version="$(date +%s)"
+  sed --in-place "s!^//version:.*!//version: $new_version!g" build.gradle
+  git add build.gradle
+  git commit -m "[ci skip] update build script version to $new_version"
+  git push
+  printf 'Updated buildscript version to %s\n' "$new_version"
+else
+  printf 'Ignored buildscript version update: no changes detected\n'
+fi

--- a/addon.gradle
+++ b/addon.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.github.gmazzo.buildconfig'
+apply plugin: 'org.jetbrains.kotlin.kapt'
 
 compileKotlin {
     kotlinOptions {
@@ -11,4 +12,17 @@ buildConfig {
     packageName("elan.tweaks.thaumcraft.research.frontend.integration")
     buildConfigField('String', 'MODVER', "\"${project.modVersion}\"")
     useKotlinOutput { topLevelConstants = true }
+}
+
+def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
+def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
+def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
+
+kapt {
+    correctErrorTypes = true
+    javacOptions {
+        option("-AreobfSrgFile=${tasks.reobf.srg}")
+        option("-AoutSrgFile=$mixinSrg")
+        option("-AoutRefMapFile=$refMap")
+    }
 }

--- a/addon.gradle
+++ b/addon.gradle
@@ -14,15 +14,20 @@ buildConfig {
     useKotlinOutput { topLevelConstants = true }
 }
 
-def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
-def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
-def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
+if (usesMixins.toBoolean()) {
+    def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
+    def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
+    def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
-kapt {
-    correctErrorTypes = true
-    javacOptions {
-        option("-AreobfSrgFile=${tasks.reobf.srg}")
-        option("-AoutSrgFile=$mixinSrg")
-        option("-AoutRefMapFile=$refMap")
+    kapt {
+        correctErrorTypes = true
+        javacOptions {
+            option("-AreobfSrgFile=${tasks.reobf.srg}")
+            option("-AoutSrgFile=$mixinSrg")
+            option("-AoutRefMapFile=$refMap")
+        }
+    }
+    jar {
+        from refMap
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,57 +1,87 @@
-/* DO NOT OVERWRITE THIS WITH THE UNIFIED BUILDSCRIPT IT DOESN'T HANDLE KOTLIN MIXINS */
+//version: 1669411416
+/*
+ DO NOT CHANGE THIS FILE!
+ Also, you may replace this file at any time if there is an update available.
+ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/master/build.gradle for updates.
+ */
 
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.gradle.internal.logging.text.StyledTextOutput.Style
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.matthewprenger.cursegradle.CurseArtifact
+import com.matthewprenger.cursegradle.CurseRelation
+import com.modrinth.minotaur.dependencies.ModDependency
+import com.modrinth.minotaur.dependencies.VersionDependency
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            name 'Overmind forge repo mirror'
-            url 'https://gregtech.overminddl1.com/'
-        }
+
         maven {
             name 'forge'
             url 'https://maven.minecraftforge.net'
+        }
+        maven {
+            // GTNH ForgeGradle Fork
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
         maven {
             name 'sonatype'
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
         maven {
-            name 'jitpack'
-            url 'https://jitpack.io'
+            name 'Scala CI dependencies'
+            url 'https://repo1.maven.org/maven2/'
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7.1'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.11'
     }
 }
-
 plugins {
     id 'java-library'
     id 'idea'
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm'        version '1.5.30' apply false
-    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'
-    id 'org.ajoberstar.grgit'            version '4.1.1'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.30' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.5.30' apply false
+    id 'com.google.devtools.ksp' version '1.5.30-1.0.0' apply false
+    id 'org.ajoberstar.grgit' version '4.1.1'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.palantir.git-version'        version '0.13.0' apply false
-    id 'de.undercouch.download'          version '5.0.1'
-    id 'com.github.gmazzo.buildconfig'   version '3.0.3'  apply false
+    id 'com.palantir.git-version' version '0.13.0' apply false
+    id 'de.undercouch.download' version '5.0.1'
+    id 'com.github.gmazzo.buildconfig' version '3.0.3' apply false
+    id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.modrinth.minotaur' version '2.+' apply false
+    id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
 }
+boolean settingsupdated = verifySettingsGradle()
+settingsupdated = verifyGitAttributes() || settingsupdated
+if (settingsupdated)
+    throw new GradleException("Settings has been updated, please re-run task.")
+
+dependencies {
+    implementation 'com.diffplug:blowdryer:1.6.0'
+}
+
+apply plugin: 'com.diffplug.blowdryer'
 
 if (project.file('.git/HEAD').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
+
+def out = services.get(StyledTextOutputFactory).create('an-output')
 
 apply plugin: 'forge'
 
@@ -71,7 +101,14 @@ idea {
     }
 }
 
-if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+boolean disableSpotless = project.hasProperty("disableSpotless") ? project.disableSpotless.toBoolean() : false
+
+if (!disableSpotless) {
+    apply plugin: 'com.diffplug.spotless'
+    apply from: Blowdryer.file('spotless.gradle')
+}
+
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     throw new GradleException("This project requires Java 8, but it's running on " + JavaVersion.current())
 }
 
@@ -96,6 +133,83 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
+propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
+propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("channel", "stable")
+propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("modrinthProjectId", "")
+propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("curseForgeProjectId", "")
+propertyDefaultIfUnset("curseForgeRelations", "")
+
+String javaSourceDir = "src/main/java/"
+String scalaSourceDir = "src/main/scala/"
+String kotlinSourceDir = "src/main/kotlin/"
+
+
+final String modGroupPath = modGroup.toString().replaceAll("\\.", "/")
+final String apiPackagePath = apiPackage.toString().replaceAll("\\.", "/")
+
+String targetPackageJava = javaSourceDir + modGroupPath
+String targetPackageScala = scalaSourceDir + modGroupPath
+String targetPackageKotlin = kotlinSourceDir + modGroupPath
+if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+    throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
+}
+
+if (apiPackage) {
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + apiPackagePath
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
+    }
+}
+
+if (accessTransformersFile) {
+    String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
+    if (!getFile(targetFile).exists()) {
+        throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
+    }
+}
+
+if (usesMixins.toBoolean()) {
+    if (mixinsPackage.isEmpty()) {
+        throw new GradleException("\"usesMixins\" requires \"mixinsPackage\" to be set!")
+    }
+    final String mixinPackagePath = mixinsPackage.toString().replaceAll("\\.", "/")
+    final String mixinPluginPath = mixinPlugin.toString().replaceAll("\\.", "/")
+
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPackagePath
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
+    }
+
+    if (!mixinPlugin.isEmpty()) {
+        String targetFileJava = javaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileScala = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".scala"
+        String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPluginPath + ".kt"
+        if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+            throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+        }
+    }
+}
+
+if (coreModClass) {
+    final String coreModPath = coreModClass.toString().replaceAll("\\.", "/")
+    String targetFileJava = javaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileScala = scalaSourceDir + modGroupPath + "/" + coreModPath + ".scala"
+    String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + coreModPath + ".kt"
+    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+        throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+    }
+}
+
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
 
@@ -108,7 +222,7 @@ configurations.all {
 try {
     'git config core.fileMode false'.execute()
 }
-catch (Exception e) {
+catch (Exception ignored) {
     out.style(Style.Failure).println("git isn't installed at all")
 }
 
@@ -118,11 +232,11 @@ String versionOverride = System.getenv("VERSION") ?: null
 try {
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
 }
-catch (Exception e) {
+catch (Exception ignored) {
     out.style(Style.Failure).text(
-            'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
+        'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
             'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
-            'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
+        'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
     )
     versionOverride = 'NO-GIT-TAG-SET'
     identifiedVersion = versionOverride
@@ -132,46 +246,49 @@ ext {
     modVersion = identifiedVersion
 }
 
-if( identifiedVersion.equals(versionOverride) ) {
+if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
 group = modGroup
-if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
+if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
     archivesBaseName = customArchiveBaseName
-}
-else {
+} else {
     archivesBaseName = modId
 }
 
 def arguments = []
 def jvmArguments = []
 
-if(usesMixins.toBoolean()) {
+if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
     arguments += [
-            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
-    jvmArguments += [
-            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
-    ]
+    if (usesMixinDebug.toBoolean()) {
+        jvmArguments += [
+            "-Dmixin.debug.countInjections=true",
+            "-Dmixin.debug.verbose=true",
+            "-Dmixin.debug.export=true"
+        ]
+    }
 }
 
 minecraft {
-    version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
-    runDir = "run"
+    version = minecraftVersion + '-' + forgeVersion + '-' + minecraftVersion
+    runDir = 'run'
 
     if (replaceGradleTokenInFile) {
         replaceIn replaceGradleTokenInFile
-        if(gradleTokenModId) {
+        if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }
-        if(gradleTokenModName) {
+        if (gradleTokenModName) {
             replace gradleTokenModName, modName
         }
-        if(gradleTokenVersion) {
+        if (gradleTokenVersion) {
             replace gradleTokenVersion, modVersion
         }
-        if(gradleTokenGroupName) {
+        if (gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
         }
     }
@@ -180,7 +297,7 @@ minecraft {
         args(arguments)
         jvmArgs(jvmArguments)
 
-        if(developmentEnvironmentUserName) {
+        if (developmentEnvironmentUserName) {
             args("--username", developmentEnvironmentUserName)
         }
     }
@@ -191,8 +308,8 @@ minecraft {
     }
 }
 
-if(file("addon.gradle").exists()) {
-    apply from: "addon.gradle"
+if (file('addon.gradle').exists()) {
+    apply from: 'addon.gradle'
 }
 
 apply from: 'repositories.gradle'
@@ -208,118 +325,125 @@ repositories {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
     }
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         maven {
-            name 'sponge'
-            url 'https://repo.spongepowered.org/repository/maven-public'
-        }
-        maven {
-            url 'https://jitpack.io'
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
     }
 }
 
 dependencies {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        kapt('org.spongepowered:mixin:0.8-SNAPSHOT')
-        // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
-            // Mixin includes a lot of dependencies that are too up-to-date
-            exclude module: 'launchwrapper'
-            exclude module: 'guava'
-            exclude module: 'gson'
-            exclude module: 'commons-io'
-            exclude module: 'log4j-core'
-        }
-        compile('com.github.GTNewHorizons:SpongeMixins:1.5.0')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.1:processor')
+    }
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+        compile('com.gtnewhorizon:gtnhmixins:2.1.1')
     }
 }
 
 apply from: 'dependencies.gradle'
 
-processResources {
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
-
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-
-        // replace modVersion and minecraftVersion
-        expand "minecraftVersion": project.minecraft.version,
-            "modVersion": modVersion,
-            "modId": modId,
-            "modName": modName
-    }
-
-    // copy everything else that's not the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
-    }
-}
-
-task devJar(type: Jar) {
-    from sourceSets.main.output
-    archiveClassifier.set("dev")
-}
-
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allJava
-    archiveClassifier.set("sources")
-}
-
-artifacts {
-    archives devJar
-    archives sourcesJar
-}
-
-def mixinConfigJson = "mixins.${modId}.json"
-def mixingConfigRefMap = "mixins.${modId}.refmap.json"
+def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
 def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
 def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
-jar {
-    from refMap
+task generateAssets {
+    if (usesMixins.toBoolean()) {
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json")
+        if (!mixinConfigFile.exists()) {
+            def mixinPluginLine = ""
+            if(!mixinPlugin.isEmpty()) {
+                // We might not have a mixin plugin if we're using early/late mixins
+                mixinPluginLine +=   """\n  "plugin": "${modGroup}.${mixinPlugin}", """
+            }
+
+            mixinConfigFile.text = """{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "package": "${modGroup}.${mixinsPackage}",${mixinPluginLine}
+  "refmap": "${mixingConfigRefMap}",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
+}
+"""
+        }
+    }
+}
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+    target = tasks.shadowJar
+    prefix = modGroup + ".shadow"
+}
+
+shadowJar {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
     manifest {
-        attributes([
-                "TweakClass"                 : "org.spongepowered.asm.launch.MixinTweaker",
-                "MixinConfigs"               : mixinConfigJson,
-                "FMLCorePluginContainsFMLMod": true,
-                "ForceLoadAsMod"             : true
-        ])
+        attributes(getManifestAttributes())
+    }
+
+    minimize()  // This will only allow shading for actually used classes
+    configurations = [
+        project.configurations.shadowImplementation,
+        project.configurations.shadowCompile
+    ]
+    dependsOn(relocateShadowJar)
+}
+
+jar {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
+    manifest {
+        attributes(getManifestAttributes())
+    }
+
+    if (usesShadowedDependencies.toBoolean()) {
+        dependsOn(shadowJar)
+        enabled = false
     }
 }
 
 reobf {
-    addExtraSrgFile mixinSrg
-}
-
-kapt {
-    correctErrorTypes = true
-    javacOptions {
-        option("-AreobfSrgFile=${tasks.reobf.srg}")
-        option("-AoutSrgFile=$mixinSrg")
-        option("-AoutRefMapFile=$refMap")
+    if (usesMixins.toBoolean()) {
+        addExtraSrgFile mixinSrg
     }
 }
 
 afterEvaluate {
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-        kotlinOptions {
-            jvmTarget = "1.8"
+    if (usesMixins.toBoolean()) {
+        tasks.compileJava {
+            options.compilerArgs += [
+                "-AreobfSrgFile=${tasks.reobf.srg}",
+                "-AoutSrgFile=${mixinSrg}",
+                "-AoutRefMapFile=${refMap}",
+                // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
+                "-XDenableSunApiLintControl",
+                "-XDignore.symbol.file"
+            ]
         }
     }
 }
 
 runClient {
-    if(developmentEnvironmentUserName) {
+    if (developmentEnvironmentUserName) {
         arguments += [
-                "--username",
-                developmentEnvironmentUserName
+            "--username",
+            developmentEnvironmentUserName
         ]
     }
 
@@ -332,33 +456,196 @@ runServer {
     jvmArgs(jvmArguments)
 }
 
+tasks.withType(JavaExec).configureEach {
+    javaLauncher.set(
+        javaToolchains.launcherFor {
+            languageVersion = projectJavaVersion
+        }
+    )
+}
+
+processResources {
+    // this will ensure that this task is redone when the versions change.
+    inputs.property "version", project.version
+    inputs.property "mcversion", project.minecraft.version
+    exclude("spotless.gradle")
+
+    // replace stuff in mcmod.info, nothing else
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
+
+        // replace modVersion and minecraftVersion
+        expand "minecraftVersion": project.minecraft.version,
+            "modVersion": modVersion,
+            "modId": modId,
+            "modName": modName
+    }
+
+    if (usesMixins.toBoolean()) {
+        from refMap
+    }
+
+    // copy everything else that's not the mcmod.info
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'mcmod.info'
+        exclude 'spotless.gradle'
+    }
+}
+
+def getManifestAttributes() {
+    def manifestAttributes = [:]
+    if (!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
+        manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
+    }
+
+    if (accessTransformersFile) {
+        manifestAttributes += ["FMLAT": accessTransformersFile.toString()]
+    }
+
+    if (coreModClass) {
+        manifestAttributes += ["FMLCorePlugin": modGroup + "." + coreModClass]
+    }
+
+    if (usesMixins.toBoolean()) {
+        manifestAttributes += [
+            "TweakClass"    : "org.spongepowered.asm.launch.MixinTweaker",
+            "MixinConfigs"  : "mixins." + modId + ".json",
+            "ForceLoadAsMod": !containsMixinsAndOrCoreModOnly.toBoolean()
+        ]
+    }
+    return manifestAttributes
+}
+
+task sourcesJar(type: Jar) {
+    from(sourceSets.main.allSource)
+    from(file("$projectDir/LICENSE"))
+    getArchiveClassifier().set('sources')
+}
+
+task shadowDevJar(type: ShadowJar) {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
+    from sourceSets.main.output
+    getArchiveClassifier().set("dev")
+
+    manifest {
+        attributes(getManifestAttributes())
+    }
+
+    minimize()  // This will only allow shading for actually used classes
+    configurations = [
+        project.configurations.shadowImplementation,
+        project.configurations.shadowCompile
+    ]
+}
+
+task relocateShadowDevJar(type: ConfigureShadowRelocation) {
+    target = tasks.shadowDevJar
+    prefix = modGroup + ".shadow"
+}
+
+task circularResolverJar(type: Jar) {
+    dependsOn(relocateShadowDevJar)
+    dependsOn(shadowDevJar)
+    enabled = false
+}
+
+task devJar(type: Jar) {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
+    from sourceSets.main.output
+    getArchiveClassifier().set("dev")
+
+    manifest {
+        attributes(getManifestAttributes())
+    }
+
+    if (usesShadowedDependencies.toBoolean()) {
+        dependsOn(circularResolverJar)
+        enabled = false
+    }
+}
+
+task apiJar(type: Jar) {
+    from(sourceSets.main.allSource) {
+        include modGroupPath + "/" + apiPackagePath + '/**'
+    }
+
+    from(sourceSets.main.output) {
+        include modGroupPath + "/" + apiPackagePath + '/**'
+    }
+
+    from(sourceSets.main.resources.srcDirs) {
+        include("LICENSE")
+    }
+
+    getArchiveClassifier().set('api')
+}
+
+artifacts {
+    if (!noPublishedSources) {
+        archives sourcesJar
+    }
+    archives devJar
+    if (apiPackage) {
+        archives apiJar
+    }
+}
+
 // The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID),
 // and isn't strictly needed with the POM so just disable it.
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
+// workaround variable hiding in pom processing
+def projectConfigs = project.configurations
+
 publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            artifact source: devJar, classifier: "dev"
+            if (usesShadowedDependencies.toBoolean()) {
+                artifact source: shadowJar, classifier: ""
+            }
+            if (!noPublishedSources) {
+                artifact source: sourcesJar, classifier: "sources"
+            }
+            artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
+            if (apiPackage) {
+                artifact source: apiJar, classifier: "api"
+            }
 
             groupId = System.getenv("ARTIFACT_GROUP_ID") ?: "com.github.GTNewHorizons"
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
-            version = System.getenv("RELEASE_VERSION") ?: modVersion
+            version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
 
-            // remove extra garbage from who knows where
+            // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
-                def badPomGroup = ['net.minecraft', 'com.google.code.findbugs', 'org.ow2.asm', 'com.typesafe.akka', 'com.typesafe', 'org.scala-lang',
-                                   'org.scala-lang.plugins', 'net.sf.jopt-simple', 'lzma', 'com.mojang', 'org.apache.commons', 'org.apache.httpcomponents',
-                                   'commons-logging', 'java3d', 'net.sf.trove4j', 'com.ibm.icu', 'com.paulscode', 'io.netty', 'com.google.guava',
-                                   'commons-io', 'commons-codec', 'net.java.jinput', 'net.java.jutils', 'com.google.code.gson', 'org.apache.logging.log4j',
-                                   'org.lwjgl.lwjgl', 'tv.twitch', 'org.jetbrains.kotlin', '']
+                def badArtifacts = [:].withDefault { [] as Set<String> }
+                for (configuration in [
+                    projectConfigs.minecraft,
+                    projectConfigs.minecraftDeps
+                ]) {
+                    for (dependency in configuration.allDependencies) {
+                        badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
+                    }
+                }
+                // example for specifying extra stuff to ignore
+                // badArtifacts["org.example.group"] += "artifactName"
+
                 Node pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
-                    badPomGroup.contains(it.groupId.text())
+                    badArtifacts[it.groupId.text()].contains(it.artifactId.text())
                 }.each() {
                     it.parent().remove(it)
                 }
@@ -377,14 +664,440 @@ publishing {
     }
 }
 
+if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
+    apply plugin: 'com.modrinth.minotaur'
+
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
+
+    modrinth {
+        token = System.getenv("MODRINTH_TOKEN")
+        projectId = modrinthProjectId
+        versionNumber = identifiedVersion
+        versionType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+        changelog = changelogFile.exists() ? changelogFile.getText("UTF-8") : ""
+        uploadFile = jar
+        additionalFiles = getSecondaryArtifacts()
+        gameVersions = [minecraftVersion]
+        loaders = ["forge"]
+        debugMode = false
+    }
+
+    if (modrinthRelations.size() != 0) {
+        String[] deps = modrinthRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            String[] qual = parts[0].split("-")
+            addModrinthDep(qual[0], qual[1], parts[1])
+        }
+    }
+    if (usesMixins.toBoolean()) {
+        addModrinthDep("required", "version", "gtnhmixins")
+    }
+    tasks.modrinth.dependsOn(build)
+    tasks.publish.dependsOn(tasks.modrinth)
+}
+
+if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null) {
+    apply plugin: 'com.matthewprenger.cursegradle'
+
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
+
+    curseforge {
+        apiKey = System.getenv("CURSEFORGE_TOKEN")
+        project {
+            id = curseForgeProjectId
+            if (changelogFile.exists()) {
+                changelogType = "markdown"
+                changelog = changelogFile
+            }
+            releaseType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+            addGameVersion minecraftVersion
+            addGameVersion "Forge"
+            mainArtifact jar
+            for (artifact in getSecondaryArtifacts()) addArtifact artifact
+        }
+
+        options {
+            javaIntegration = false
+            forgeGradleIntegration = false
+            debug = false
+        }
+    }
+
+    if (curseForgeRelations.size() != 0) {
+        String[] deps = curseForgeRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            addCurseForgeRelation(parts[0], parts[1])
+        }
+    }
+    if (usesMixins.toBoolean()) {
+        addCurseForgeRelation("requiredDependency", "gtnhmixins")
+    }
+    tasks.curseforge.dependsOn(build)
+    tasks.publish.dependsOn(tasks.curseforge)
+}
+
+def addModrinthDep(scope, type, name) {
+    com.modrinth.minotaur.dependencies.Dependency dep;
+    if (!(scope in ["required", "optional", "incompatible", "embedded"])) {
+        throw new Exception("Invalid modrinth dependency scope: " + scope)
+    }
+    switch (type) {
+        case "project":
+            dep = new ModDependency(name, scope)
+            break
+        case "version":
+            dep = new VersionDependency(name, scope)
+            break
+        default:
+            throw new Exception("Invalid modrinth dependency type: " + type)
+    }
+    project.modrinth.dependencies.add(dep)
+}
+
+def addCurseForgeRelation(type, name) {
+    if (!(type in ["requiredDependency", "embeddedLibrary", "optionalDependency", "tool", "incompatible"])) {
+        throw new Exception("Invalid CurseForge relation type: " + type)
+    }
+    CurseArtifact artifact = project.curseforge.curseProjects[0].mainArtifact
+    CurseRelation rel = (artifact.curseRelations ?: (artifact.curseRelations = new CurseRelation()))
+    rel."$type"(name)
+}
+
+// Updating
+task updateBuildScript {
+    doLast {
+        if (performBuildScriptUpdate(projectDir.toString())) return
+
+        print("Build script already up-to-date!")
+    }
+}
+
+if (!project.getGradle().startParameter.isOffline() && isNewBuildScriptVersionAvailable(projectDir.toString())) {
+    if (autoUpdateBuildScript.toBoolean()) {
+        performBuildScriptUpdate(projectDir.toString())
+    } else {
+        out.style(Style.SuccessHeader).println("Build script update available! Run 'gradle updateBuildScript'")
+    }
+}
+
+static URL availableBuildScriptUrl() {
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/build.gradle")
+}
+
+static URL exampleSettingsGradleUrl() {
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/settings.gradle.example")
+}
+
+static URL exampleGitAttributesUrl() {
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/.gitattributes")
+}
+
+
+boolean verifyGitAttributes() {
+    def gitattributesFile = getFile(".gitattributes")
+    if (!gitattributesFile.exists()) {
+        println("Downloading default .gitattributes")
+        exampleGitAttributesUrl().withInputStream { i -> gitattributesFile.withOutputStream { it << i } }
+        exec {
+            workingDir '.'
+            commandLine 'git', 'add', '--renormalize', '.'
+        }
+        return true
+    }
+    return false
+}
+
+boolean verifySettingsGradle() {
+    def settingsFile = getFile("settings.gradle")
+    if (!settingsFile.exists()) {
+        println("Downloading default settings.gradle")
+        exampleSettingsGradleUrl().withInputStream { i -> settingsFile.withOutputStream { it << i } }
+        return true
+    }
+    return false
+}
+
+boolean performBuildScriptUpdate(String projectDir) {
+    if (isNewBuildScriptVersionAvailable(projectDir)) {
+        def buildscriptFile = getFile("build.gradle")
+        availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
+        out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
+        boolean settingsupdated = verifySettingsGradle()
+        settingsupdated = verifyGitAttributes() || settingsupdated
+        if (settingsupdated)
+            throw new GradleException("Settings has been updated, please re-run task.")
+        return true
+    }
+    return false
+}
+
+boolean isNewBuildScriptVersionAvailable(String projectDir) {
+    Map parameters = ["connectTimeout": 2000, "readTimeout": 2000]
+
+    String currentBuildScript = getFile("build.gradle").getText()
+    String currentBuildScriptHash = getVersionHash(currentBuildScript)
+    String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
+    String availableBuildScriptHash = getVersionHash(availableBuildScript)
+
+    boolean isUpToDate = currentBuildScriptHash.empty || availableBuildScriptHash.empty || currentBuildScriptHash == availableBuildScriptHash
+    return !isUpToDate
+}
+
+static String getVersionHash(String buildScriptContent) {
+    String versionLine = buildScriptContent.find("^//version: [a-z0-9]*")
+    if (versionLine != null) {
+        return versionLine.split(": ").last()
+    }
+    return ""
+}
+
+configure(updateBuildScript) {
+    group = 'forgegradle'
+    description = 'Updates the build script to the latest version'
+}
+
+// Parameter Deobfuscation
+
+task deobfParams {
+    doLast {
+
+        String mcpDir = "$project.gradle.gradleUserHomeDir/caches/minecraft/de/oceanlabs/mcp/mcp_$channel/$mappingsVersion"
+        String mcpZIP = "$mcpDir/mcp_$channel-$mappingsVersion-${minecraftVersion}.zip"
+        String paramsCSV = "$mcpDir/params.csv"
+
+        download.run {
+            src "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_$channel/$mappingsVersion-$minecraftVersion/mcp_$channel-$mappingsVersion-${minecraftVersion}.zip"
+            dest mcpZIP
+            overwrite false
+        }
+
+        if (!file(paramsCSV).exists()) {
+            println("Extracting MCP archive ...")
+            unzip(mcpZIP, mcpDir)
+        }
+
+        println("Parsing params.csv ...")
+        Map<String, String> params = new HashMap<>()
+        Files.lines(Paths.get(paramsCSV)).forEach { line ->
+            String[] cells = line.split(",")
+            if (cells.length > 2 && cells[0].matches("p_i?\\d+_\\d+_")) {
+                params.put(cells[0], cells[1])
+            }
+        }
+
+        out.style(Style.Success).println("Modified ${replaceParams(file("$projectDir/src/main/java"), params)} files!")
+        out.style(Style.Failure).println("Don't forget to verify that the code still works as before!\n It could be broken due to duplicate variables existing now\n or parameters taking priority over other variables.")
+    }
+}
+
+static int replaceParams(File file, Map<String, String> params) {
+    int fileCount = 0
+
+    if (file.isDirectory()) {
+        for (File f : file.listFiles()) {
+            fileCount += replaceParams(f, params)
+        }
+        return fileCount
+    }
+    println("Visiting ${file.getName()} ...")
+    try {
+        String content = new String(Files.readAllBytes(file.toPath()))
+        int hash = content.hashCode()
+        params.forEach { key, value ->
+            content = content.replaceAll(key, value)
+        }
+        if (hash != content.hashCode()) {
+            Files.write(file.toPath(), content.getBytes("UTF-8"))
+            return 1
+        }
+    } catch (Exception e) {
+        e.printStackTrace()
+    }
+    return 0
+}
+
+// Credit: bitsnaps (https://gist.github.com/bitsnaps/00947f2dce66f4bbdabc67d7e7b33681)
+static unzip(String zipFileName, String outputDir) {
+    byte[] buffer = new byte[16384]
+    ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFileName))
+    ZipEntry zipEntry = zis.getNextEntry()
+    while (zipEntry != null) {
+        File newFile = new File(outputDir + File.separator, zipEntry.name)
+        if (zipEntry.isDirectory()) {
+            if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                throw new IOException("Failed to create directory $newFile")
+            }
+        } else {
+            // fix for Windows-created archives
+            File parent = newFile.parentFile
+            if (!parent.isDirectory() && !parent.mkdirs()) {
+                throw new IOException("Failed to create directory $parent")
+            }
+            // write file content
+            FileOutputStream fos = new FileOutputStream(newFile)
+            int len = 0
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len)
+            }
+            fos.close()
+        }
+        zipEntry = zis.getNextEntry()
+    }
+    zis.closeEntry()
+    zis.close()
+}
+
+configure(deobfParams) {
+    group = 'forgegradle'
+    description = 'Rename all obfuscated parameter names inherited from Minecraft classes'
+}
+
+// Dependency Deobfuscation
+
+def deobf(String sourceURL) {
+    try {
+        URL url = new URL(sourceURL)
+        String fileName = url.getFile()
+
+        //get rid of directories:
+        int lastSlash = fileName.lastIndexOf("/")
+        if (lastSlash > 0) {
+            fileName = fileName.substring(lastSlash + 1)
+        }
+        //get rid of extension:
+        if (fileName.endsWith(".jar") || fileName.endsWith(".litemod")) {
+            fileName = fileName.substring(0, fileName.lastIndexOf("."))
+        }
+
+        String hostName = url.getHost()
+        if (hostName.startsWith("www.")) {
+            hostName = hostName.substring(4)
+        }
+        List parts = Arrays.asList(hostName.split("\\."))
+        Collections.reverse(parts)
+        hostName = String.join(".", parts)
+
+        return deobf(sourceURL, "$hostName/$fileName")
+    } catch (Exception e) {
+        return deobf(sourceURL, "deobf/${sourceURL.hashCode()}")
+    }
+}
+
+// The method above is to be preferred. Use this method if the filename is not at the end of the URL.
+def deobf(String sourceURL, String rawFileName) {
+    String bon2Version = "2.5.1"
+    String fileName = URLDecoder.decode(rawFileName, "UTF-8")
+    String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
+    String bon2Dir = "$cacheDir/forge_gradle/deobf"
+    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
+    String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
+    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
+
+    if (file(deobfFile).exists()) {
+        return files(deobfFile)
+    }
+
+    String mappingsVer
+    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
+    if (remoteMappings) {
+        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
+        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
+
+        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
+
+        mappingsVer = "snapshot_$id"
+    } else {
+        mappingsVer = "${channel}_$mappingsVersion"
+    }
+
+    download.run {
+        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
+        dest bon2File
+        quiet true
+        overwrite false
+    }
+
+    download.run {
+        src sourceURL
+        dest obfFile
+        quiet true
+        overwrite false
+    }
+
+    exec {
+        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
+        workingDir bon2Dir
+        standardOutput = new FileOutputStream("${deobfFile}.log")
+    }
+
+    return files(deobfFile)
+}
+
+def zipMappings(String zipPath, String url, String bon2Dir) {
+    File zipFile = new File(zipPath)
+    if (zipFile.exists()) {
+        return
+    }
+
+    String fieldsCache = "$bon2Dir/data/fields.csv"
+    String methodsCache = "$bon2Dir/data/methods.csv"
+
+    download.run {
+        src "${url}fields.csv"
+        dest fieldsCache
+        quiet true
+    }
+    download.run {
+        src "${url}methods.csv"
+        dest methodsCache
+        quiet true
+    }
+
+    zipFile.getParentFile().mkdirs()
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
+
+    zos.putNextEntry(new ZipEntry("fields.csv"))
+    Files.copy(Paths.get(fieldsCache), zos)
+    zos.closeEntry()
+
+    zos.putNextEntry(new ZipEntry("methods.csv"))
+    Files.copy(Paths.get(methodsCache), zos)
+    zos.closeEntry()
+
+    zos.close()
+}
+
 // Helper methods
 
 def checkPropertyExists(String propertyName) {
-    if (project.hasProperty(propertyName) == false) {
+    if (!project.hasProperty(propertyName)) {
         throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
+    }
+}
+
+def propertyDefaultIfUnset(String propertyName, defaultValue) {
+    if (!project.hasProperty(propertyName) || project.property(propertyName) == "") {
+        project.ext.setProperty(propertyName, defaultValue)
     }
 }
 
 def getFile(String relativePath) {
     return new File(projectDir, relativePath)
+}
+
+def getSecondaryArtifacts() {
+    // Because noPublishedSources from the beginning of the script is somehow not visible here...
+    boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+    def secondaryArtifacts = [devJar]
+    if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
+    if (apiPackage) secondaryArtifacts += [apiJar]
+    return secondaryArtifacts
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,4 +10,8 @@ dependencies {
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
     testImplementation("org.assertj:assertj-core:3.20.2")
+
+    if(usesMixins.toBoolean()) {
+        kapt('com.gtnewhorizon:gtnhmixins:2.1.1:processor')
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,13 @@ autoUpdateBuildScript = false
 minecraftVersion = 1.7.10
 forgeVersion = 10.13.4.1614
 
+# Specify a MCP channel and mappings version for dependency deobfuscation and the deobfParams task.
+channel = stable
+mappingsVersion = 12
+
+# Define other MCP mappings for dependency deobfuscation
+remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+
 # Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
 # restart Minecraft in development. Choose this dependent on your mod:
 # Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
@@ -31,6 +38,7 @@ gradleTokenModId =
 gradleTokenModName =
 gradleTokenVersion = GRADLETOKEN_VERSION
 gradleTokenGroupName =
+
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
 # Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
@@ -42,10 +50,12 @@ accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
+# Adds some debug arguments like verbose output and export
+usesMixinDebug = false
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
-mixinsPackage =
+mixinsPackage = frontend.integration.table.mixin
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # This parameter is for legacy compatibility only
 # Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
@@ -54,13 +64,53 @@ coreModClass =
 # that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
 containsMixinsAndOrCoreModOnly = false
 
+# Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
+forceEnableMixins = false
+
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
 
+
+# Publishing to modrinth requires you to set the MODRINTH_TOKEN environment variable to your current modrinth API token.
+
+# The project's ID on Modrinth. Can be either the slug or the ID.
+# Leave this empty if you don't want to publish on Modrinth.
+modrinthProjectId =
+
+# The project's relations on Modrinth. You can use this to refer to other projects on Modrinth.
+# Syntax: scope1-type1:name1;scope2-type2:name2;...
+# Where scope can be one of [required, optional, incompatible, embedded],
+#       type can be one of [project, version],
+#       and the name is the Modrinth project or version slug/id of the other mod.
+# Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+modrinthRelations =
+
+
+# Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.
+
+# The project's numeric ID on CurseForge. You can find this in the About Project box.
+# Leave this empty if you don't want to publish on CurseForge.
+curseForgeProjectId =
+
+# The project's relations on CurseForge. You can use this to refer to other projects on CurseForge.
+# Syntax: type1:name1;type2:name2;...
+# Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
+#       and the name is the CurseForge project slug of the other mod.
+# Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
+# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+curseForgeRelations =
+
+
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.
-#customArchiveBaseName =
+# customArchiveBaseName =
 
 # Optional parameter to prevent the source code from being published
 # noPublishedSources =
+
+# Uncomment this to disable spotless checks
+# This should only be uncommented to keep it easier to sync with upstream/other forks.
+# That is, if there is no other active fork/upstream, NEVER change this.
+# disableSpotless = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - ./gradlew setupCIWorkspace

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,10 @@
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
+plugins {
+    id 'com.diffplug.blowdryerSetup' version '1.6.0'
+}
+
+apply plugin: 'com.diffplug.blowdryerSetup'
+
+blowdryerSetup {
+    //github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.5')
+    devLocal '.' // Use this when testing config updates locally
 }

--- a/src/main/kotlin/elan/tweaks/common/gui/ComposableContainerGui.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/ComposableContainerGui.kt
@@ -98,7 +98,7 @@ class ComposableContainerGui(
     }
 
     private fun handleDraggables(button: MouseButton, uiMousePosition: Vector3D) {
-        if (button is MouseButton.Left) handleDragAttempt(uiMousePosition) 
+        if (button is MouseButton.Left) handleDragAttempt(uiMousePosition)
         else handleDragClickables(uiMousePosition, button)
     }
 

--- a/src/main/kotlin/elan/tweaks/common/gui/component/UIContext.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/component/UIContext.kt
@@ -9,22 +9,22 @@ import java.util.*
 
 interface UIContext {
     val random: Random
-    
+
     fun drawBlending(texture: TextureInstance, uiPosition: VectorXY, colorMask: Rgba  = Rgba(1f,1f,1f,1f))
     fun drawWithShadow(text: String, uiPosition: VectorXY = Vector2D.ZERO)
-    
+
     fun drawTag(aspect: Aspect, amount: Int, uiPosition: VectorXY = Vector2D.ZERO)
     fun drawTag(aspect: Aspect, amount: Int = 0, bonus: Int = 0, blend: Int = 771, alpha: Float = 1f, uiPosition: VectorXY = Vector2D.ZERO)
     fun drawTagMonochrome(aspect: Aspect, alpha: Float = 0.66f, uiPosition: VectorXY = Vector2D.ZERO)
-    
+
     fun drawTooltip(uiPosition: VectorXY = Vector2D.ZERO, vararg text: String)
     fun drawTooltipCentered(uiCenterPosition: VectorXY = Vector2D.ZERO, vararg text: String)
-    
+
     fun drawOrb(uiPosition: VectorXY, color: Int)
     fun drawOrb(uiPosition: VectorXY)
-    
+
     fun drawLine(from: VectorXY, to: VectorXY)
-    
+
     fun playSound(
         soundName: String,
         volume: Float,

--- a/src/main/kotlin/elan/tweaks/common/gui/component/dragndrop/DragAndDropUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/component/dragndrop/DragAndDropUIComponent.kt
@@ -5,7 +5,7 @@ import elan.tweaks.common.gui.component.UIContext
 import elan.tweaks.common.gui.dto.VectorXY
 
 interface DragAndDropUIComponent: UIComponent {
-        
+
     /**
      * Called when left mouse button down and any source can provide a draggable
      */
@@ -14,12 +14,12 @@ interface DragAndDropUIComponent: UIComponent {
             onAttemptDrag(draggable, uiMousePosition, context)
         }
     }
-    
+
     /**
      * Called when left mouse button down and any source can provide a draggable
      */
     fun onAttemptDrag(draggable: Any, uiMousePosition: VectorXY, context: UIContext)
-    
+
     /**
      * Called when left mouse button is down
      */
@@ -34,5 +34,5 @@ interface DragAndDropUIComponent: UIComponent {
      * Called when mouse clicked over drag click receiver
      */
     fun onDragClick(context: UIContext): Any?
-    
+
 }

--- a/src/main/kotlin/elan/tweaks/common/gui/component/texture/TextureBackgroundUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/component/texture/TextureBackgroundUIComponent.kt
@@ -14,7 +14,7 @@ class TextureBackgroundUIComponent(
         context.drawBlending(texture, uiOrigin)
 
     companion object {
-        fun background(uiOrigin: VectorXY, texture: TextureInstance) = 
+        fun background(uiOrigin: VectorXY, texture: TextureInstance) =
             TextureBackgroundUIComponent(uiOrigin, texture)
     }
 

--- a/src/main/kotlin/elan/tweaks/common/gui/dto/Dtos.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/dto/Dtos.kt
@@ -102,7 +102,7 @@ data class HexVector(
 ) {
 
     val key: String = "$q:$r"
-    
+
     fun toOrigin(hexSize: Int): VectorXY =
         HexMath.toOrigin(q, r, hexSize)
 
@@ -114,12 +114,12 @@ data class HexVector(
 
             return HexVector(roundQ, roundR)
         }
-        
+
         private fun findRoundedCoordinates(vector: VectorXY, hexSize: Int): Pair<Int, Int> {
             val q = 0.6666666666666666 * vector.x / hexSize.toDouble()
             val r = 0.3333333333333333 * (sqrt(3.0) * -vector.y - vector.x) / hexSize.toDouble()
             val s = -q - r
-            
+
             var roundQ = q.roundToInt()
             val roundR = r.roundToInt()
             var roundS = s.roundToInt()
@@ -131,7 +131,7 @@ data class HexVector(
             } else if (deltaR <= deltaS) {
                 roundS = -roundQ - roundR
             }
-            
+
             return roundQ to roundS
         }
     }

--- a/src/main/kotlin/elan/tweaks/common/gui/fx/LineParticle.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/fx/LineParticle.kt
@@ -10,7 +10,7 @@ import kotlin.math.sin
 object LineParticle {
     fun draw(from: VectorXY, to: VectorXY) {
         val count = nextValueOfSlowlyGrowingFunction()
-        
+
         val alpha = 0.3 + sin(count.toDouble()) * 0.3 + 0.3
         GL11.glPushMatrix()
         GL11.glLineWidth(3.0f)

--- a/src/main/kotlin/elan/tweaks/common/gui/fx/OrbParticle.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/fx/OrbParticle.kt
@@ -54,7 +54,7 @@ object OrbParticle {
             addVertexWithUV(16.0, 0.0, screenOrigin.z, var8.toDouble(), var10.toDouble())
             addVertexWithUV(0.0, 0.0, screenOrigin.z, var8.toDouble(), var11.toDouble())
         }
-        
+
         GL11.glPopMatrix()
     }
 

--- a/src/main/kotlin/elan/tweaks/common/gui/layout/grid/GridLayoutDynamicListAdapter.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/layout/grid/GridLayoutDynamicListAdapter.kt
@@ -9,7 +9,7 @@ class GridLayoutDynamicListAdapter<ElementT>(
     private val cellSize: Int,
     private val provideElements: () -> List<ElementT>
 ) : GridLayout<ElementT> {
-    
+
     private val elements: List<ElementT>
         get() = provideElements()
 

--- a/src/main/kotlin/elan/tweaks/common/gui/peripheral/MouseButton.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/peripheral/MouseButton.kt
@@ -7,9 +7,9 @@ sealed class MouseButton(private val index: Int) {
     object Right: MouseButton(1)
     object Middle: MouseButton(2)
     class Unknown(index: Int): MouseButton(index)
-    
+
     fun isDown() = Mouse.isButtonDown(index)
-    
+
     companion object {
         fun of(index: Int): MouseButton = when(index) {
             0 -> Left

--- a/src/main/kotlin/elan/tweaks/common/gui/rendering/TextureRenderer.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/rendering/TextureRenderer.kt
@@ -19,9 +19,9 @@ object TextureRenderer {
         GL11.glPushMatrix()
         GL11.glEnable(GL11.GL_BLEND)
         GL11.glColor4f(colorMask.r, colorMask.g, colorMask.b, colorMask.a)
-        
+
         texture.bindAndDraw(origin, colorMask)
-        
+
         GL11.glPopMatrix()
     }
 

--- a/src/main/kotlin/elan/tweaks/common/gui/rendering/TooltipRenderer.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/rendering/TooltipRenderer.kt
@@ -42,7 +42,7 @@ object TooltipRenderer {
     private fun Array<out String>.headerHeight() =
         if (size > 1) HEADER_SPACING + LINE_HEIGHT else LINE_HEIGHT
 
-    private fun Array<out String>.bodyHeight() = 
+    private fun Array<out String>.bodyHeight() =
         (size - 2) * LINE_HEIGHT
 
     fun FontRenderer.draw(lines: Array<out String>, textScale: Scale, origin: VectorXY, subTipColorColorHex: String) {

--- a/src/main/kotlin/elan/tweaks/common/gui/textures/TextureInstance.kt
+++ b/src/main/kotlin/elan/tweaks/common/gui/textures/TextureInstance.kt
@@ -10,9 +10,9 @@ interface TextureInstance {
     val uv: UV
     val uvScale: Scale
     val textureScale: Scale
-    
+
     val resourceLocation: ResourceLocation
-    
+
     fun beforeGL() {}
     fun before(tessellator: Tessellator) {}
     fun afterGL() {}

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/failures/MissingResearchFailure.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/failures/MissingResearchFailure.kt
@@ -7,7 +7,7 @@ class MissingResearchFailure(message: String) : Exception(message) {
         fun <ResultT> missingResearchMastery() = Result.failure<ResultT>(
             MissingResearchFailure("${KnowledgeBase.RESEARCH_MASTERY} is required")
         )
-        
+
         fun <ResultT> missingResearchDuplication() = Result.failure<ResultT>(
             MissingResearchFailure("${KnowledgeBase.RESEARCH_DUPLICATION} is required")
         )

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/AspectPallet.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/AspectPallet.kt
@@ -49,11 +49,10 @@ class AspectPallet constructor(
 
     override fun isDrainedOf(aspect: Aspect): Boolean =
         pool.totalAmountOf(aspect) <= 0
-    
+
     private fun <ResultT> batch(function: () -> Result<ResultT>): Result<ResultT> {
         val batchResults = (1..batchSize).map { function() }
 
         return batchResults.firstOrNull { it.isSuccess } ?: batchResults.first()
     }
 }
-

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/AspectTree.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/AspectTree.kt
@@ -66,7 +66,7 @@ object AspectTree : AspectsTreePort {
             aspectToOrder += orderDerivable.associateWith { aspect ->
                 aspectToOrder.getValue(aspect.components[0]) + aspectToOrder.getValue(aspect.components[1])
             }
-            
+
             affinityToOrder += orderDerivable.associateWith { aspect ->
                 (affinityToOrder.getValue(aspect.components[0]) + affinityToOrder.getValue(aspect.components[1])) / 2
             }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/ResearcherKnowledge.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/model/ResearcherKnowledge.kt
@@ -12,7 +12,7 @@ class ResearcherKnowledge constructor(
 ) : ResearcherKnowledgePort {
     override fun hasDiscovered(knowledge: ResearcherKnowledgePort.Knowledge): Boolean =
         base.hasDiscovered(knowledge)
-        
+
     override fun hasDiscovered(aspect: Aspect): Boolean =
         pool.hasDiscovered(aspect)
 
@@ -20,4 +20,3 @@ class ResearcherKnowledge constructor(
         pool.allDiscovered()
 
 }
-

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/AspectPalletPort.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/AspectPalletPort.kt
@@ -10,7 +10,6 @@ interface AspectPalletPort {
 
     fun isDrainedOf(aspect: Aspect): Boolean
     fun amountAndBonusOf(aspect: Aspect): Pair<Int, Int>
-    
-    fun missing(aspectAmounts: Map<Aspect, Int>): Boolean 
-}
 
+    fun missing(aspectAmounts: Map<Aspect, Int>): Boolean
+}

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/AspectsTreePort.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/AspectsTreePort.kt
@@ -8,5 +8,5 @@ interface AspectsTreePort {
     fun orderOf(aspect: Aspect): Int
     fun allEntropyLeaning(): List<Aspect>
     fun allOrderLeaning(): List<Aspect>
-    
+
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/ResearchProcessPort.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/ResearchProcessPort.kt
@@ -4,15 +4,15 @@ import thaumcraft.api.aspects.Aspect
 import thaumcraft.common.lib.research.ResearchNoteData
 
 interface ResearchProcessPort {
-    
+
     val usedAspectAmounts: Map<Aspect, Int>
     val requiresInkToContinue: Boolean
     val data: ResearchNoteData?
-    
+
     fun notReadyToDuplicate() : Boolean = !readyToDuplicate()
     fun readyToDuplicate() : Boolean
     fun duplicate() : Result<Unit>
-    
+
     fun missingNotes(): Boolean = !notesPresent()
     fun notesPresent(): Boolean
     fun notesCorrupted(): Boolean

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/ResearcherKnowledgePort.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/provided/ResearcherKnowledgePort.kt
@@ -6,7 +6,7 @@ interface ResearcherKnowledgePort {
     fun hasDiscovered(knowledge: Knowledge): Boolean
     fun hasDiscovered(aspect: Aspect): Boolean
     fun allDiscoveredAspects(): Array<Aspect>
-    
+
     enum class Knowledge {
         ResearchExpertise,
         ResearchMastery,

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/required/AspectPool.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/required/AspectPool.kt
@@ -5,7 +5,7 @@ import thaumcraft.api.aspects.Aspect
 interface AspectPool {
     fun hasDiscovered(aspect: Aspect): Boolean
     fun allDiscovered(): Array<Aspect>
-    
+
     fun amountOf(aspect: Aspect): Int
     fun bonusAmountOf(aspect: Aspect): Int
     fun totalAmountOf(aspect: Aspect): Int

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/required/ResearchNotes.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/domain/ports/required/ResearchNotes.kt
@@ -8,13 +8,13 @@ interface ResearchNotes {
     val valid: Boolean
 
     val complete: Boolean
-    
+
     val data: ResearchNoteData?
-    
+
     fun erase(hexKey: String): Result<Unit>
     fun write(hexKey: String, aspect: Aspect): Result<Unit>
-    
+
     fun duplicate(): Result<Unit>
-    
+
     fun findUsedAspectAmounts(): Map<Aspect, Int>
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/KnowledgeBaseAdapter.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/KnowledgeBaseAdapter.kt
@@ -18,7 +18,7 @@ class KnowledgeBaseAdapter(
 
     override fun hasDiscovered(knowledge: Knowledge): Boolean =
         knowledgeToResearchKey.containsKey(knowledge) && hasDiscovered(knowledgeToResearchKey[knowledge]!!)
-    
+
     private fun hasDiscovered(researchName: String) =
         ResearchManager.isResearchComplete(player.commandSenderName, researchName)
 

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/PlayerInventoryAdapter.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/PlayerInventoryAdapter.kt
@@ -11,15 +11,15 @@ import thaumcraft.common.lib.utils.InventoryUtils
 class PlayerInventoryAdapter(
     private val player: EntityPlayer
 ): PlayerInventory {
-    
+
     companion object {
         private val paperItemStack = ItemStack(Items.paper)
         private val blackDyeItemStack = ItemStack(Items.dye, 1, 0)
     }
-    
+
     override fun containsPaper(): Boolean =
         InventoryUtils.isPlayerCarrying(player, paperItemStack) >= 0
-    
+
     override fun containsBlackDye(): Boolean =
         InventoryUtils.isPlayerCarrying(player, blackDyeItemStack) >= 0
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/ResearchNotesAdapter.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/ResearchNotesAdapter.kt
@@ -30,7 +30,7 @@ class ResearchNotesAdapter(
 
     override val valid: Boolean
         get() = validateData()
-    
+
     override val data: ResearchNoteData?
         get() = notes?.let(ResearchManager::getData)
 
@@ -76,7 +76,7 @@ class ResearchNotesAdapter(
     override fun findUsedAspectAmounts(): Map<Aspect, Int> {
         val researchData = getResearchData()
         val aspects = ResearchCategories.getResearch(researchData.key).tags
-        
+
         return aspects.getAspects().associateWith { aspect -> researchData.copies + aspects.getAmount(aspect) }
     }
 

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/ScribeToolsAdapter.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/adapters/ScribeToolsAdapter.kt
@@ -11,6 +11,6 @@ class ScribeToolsAdapter(
     override fun areMissingOrEmpty(): Boolean {
         val tools = table.getStackInSlot(SCRIBE_TOOLS_SLOT_INDEX) ?: return true
         return tools.itemDamage == tools.maxDamage
-    } 
+    }
 
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/TableUIContext.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/TableUIContext.kt
@@ -25,7 +25,7 @@ class TableUIContext(
     private val renderViewEntity: EntityLivingBase by lazy { Minecraft.getMinecraft().renderViewEntity }
     private val world: World by lazy { renderViewEntity.worldObj }
     override val random: Random by lazy { world.rand }
-    
+
     override fun drawBlending(texture: TextureInstance, uiPosition: VectorXY, colorMask: Rgba) {
         TextureRenderer.drawBlending(texture, screenOrigin + uiPosition, colorMask)
     }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/ThaumcraftResearchGuiHandler.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/ThaumcraftResearchGuiHandler.kt
@@ -37,4 +37,3 @@ class ThaumcraftResearchGuiHandler : IGuiHandler {
         getTileEntity(x, y, z) as TileResearchTable
 
 }
-

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/ResearchTableGuiFactory.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/ResearchTableGuiFactory.kt
@@ -74,7 +74,7 @@ object ResearchTableGuiFactory {
 
         val runes = Runes(
             uiOrigin = ResearchArea.bounds.origin,
-            
+
             runeLimit = 16,
 
             hexLayout = hexLayout,
@@ -101,7 +101,7 @@ object ResearchTableGuiFactory {
         val leftAspectPallet = palletComponent(
             bounds = AspectPools.leftBound,
             aspectProvider = tree::allOrderLeaning
-        ) 
+        )
 
         val rightAspectPallet = palletComponent(
             bounds = AspectPools.rightBound,

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/AspectDragAndDropUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/AspectDragAndDropUIComponent.kt
@@ -13,7 +13,7 @@ class AspectDragAndDropUIComponent(
 
     override fun onAttemptDrag(draggable: Any, uiMousePosition: VectorXY, context: UIContext) {
         if (this.draggable != null || draggable !is Aspect) return
-        
+
         this.draggable = draggable
     }
 
@@ -24,7 +24,7 @@ class AspectDragAndDropUIComponent(
         return droppedAspect
     }
 
-    override fun onDragClick(context: UIContext): Any? = 
+    override fun onDragClick(context: UIContext): Any? =
         draggable
 
     override fun onDragging(uiMousePosition: VectorXY, context: UIContext) {
@@ -33,7 +33,7 @@ class AspectDragAndDropUIComponent(
             draggable = null
             return
         }
-        
+
         context.drawOrb(uiMousePosition, draggedAspect.color)
     }
 

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/AspectPalletUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/AspectPalletUIComponent.kt
@@ -61,7 +61,7 @@ class AspectPalletUIComponent(
         }
     }
 
-    private fun Aspect.hasComponents() = 
+    private fun Aspect.hasComponents() =
         !isPrimal && components != null && components.isNotEmpty()
 
     override fun onMouseClicked(uiMousePosition: VectorXY, button: MouseButton, context: UIContext) {
@@ -84,7 +84,7 @@ class AspectPalletUIComponent(
         return aspect
     }
 
-    private fun isIntendingToDeriveAspect() = 
+    private fun isIntendingToDeriveAspect() =
         isShiftKeyDown()
 
     private fun UIContext.playButtonAspect() {
@@ -95,7 +95,7 @@ class AspectPalletUIComponent(
             false
         )
     }
-    
+
     override fun onDropped(draggable: Any, uiMousePosition: VectorXY, partialTicks: Float, context: UIContext) {
         if (draggable !is Aspect) return
 
@@ -107,7 +107,7 @@ class AspectPalletUIComponent(
 
     override fun onDragClick(draggable: Any, uiMousePosition: VectorXY, button: MouseButton, context: UIContext) {
         if (draggable !is Aspect || button !is MouseButton.Right) return
-        
+
         whenAspectAt(uiMousePosition) { targetAspect ->
             combine(draggable, targetAspect).onSuccess { context.playCombine() }
         }
@@ -117,7 +117,7 @@ class AspectPalletUIComponent(
         if (isIntendingToBatch()) pallet.combineBatch(draggable, targetAspect)
         else pallet.combine(draggable, targetAspect)
 
-    private fun isIntendingToBatch() = 
+    private fun isIntendingToBatch() =
         isCtrlKeyDown()
 
     private inline fun whenAspectAt(uiMousePosition: VectorXY, action: (Aspect) -> Unit) {

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/CopyButtonUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/CopyButtonUIComponent.kt
@@ -96,7 +96,7 @@ class CopyButtonUIComponent(
                 )
                 context.drawTag(aspect, amount, requirementsUiOrigin + tagOffset)
             }
-        
+
     }
 
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/area/AspectHexMapUIComponent.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/component/area/AspectHexMapUIComponent.kt
@@ -20,7 +20,7 @@ class AspectHexMapUIComponent(
     override fun onDrawBackground(uiMousePosition: VectorXY, partialTicks: Float, context: UIContext) {
         if (research.missingNotes()) return
         if(research.notesCorrupted()) return drawCorruptedNotes(context)
-        
+
         // with current highlight texture best effect is achieved when drawing it under border
         drawMouseOverHighlight(uiMousePosition, context)
         drawHexes(context)

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/layout/ParchmentHexMapLayout.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/layout/ParchmentHexMapLayout.kt
@@ -13,7 +13,7 @@ import java.util.*
 object ParchmentHexMapLayout {
 
     private val keyToHex: Map<String, Hex> = findAllFittingHexes()
-    override fun toString(): String = 
+    override fun toString(): String =
         "ParchmentHexMapLayout: $keyToHex"
 
     fun randomHex() = keyToHex.entries.random()
@@ -27,7 +27,7 @@ object ParchmentHexMapLayout {
         val hexesToTraverse = Stack<HexUtils.Hex>()
         hexesToTraverse += HexUtils.Hex(0, 0)
         visitedKeys += "0:0"
-        
+
         while (hexesToTraverse.isNotEmpty()) {
             val hex = hexesToTraverse.pop()
 

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/HexHighlightTexture.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/HexHighlightTexture.kt
@@ -12,12 +12,12 @@ object HexHighlightTexture : ThaumcraftTextureInstance(
     scale = Scale.cube(16),
 ) {
     val colorMask = Rgba(1f, 1f, 1f, 1f)
-    
+
     override fun beforeGL() {
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f)
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, 1)
     }
-    
+
     override fun before(tessellator: Tessellator) {
         tessellator.setBrightness(240)
     }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/HexTexture.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/HexTexture.kt
@@ -13,7 +13,7 @@ object HexTexture : ThaumcraftTextureInstance(
 ) {
     const val SIZE_PIXELS = 9
     val colorMask = Rgba(1f, 1f, 1f, 0.25f)
-    
+
     override fun beforeGL() {
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569f)
     }
@@ -25,5 +25,5 @@ object HexTexture : ThaumcraftTextureInstance(
     override fun afterGL() {
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.1f)
     }
-    
+
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/PlayerInventoryTexture.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/PlayerInventoryTexture.kt
@@ -45,4 +45,3 @@ object PlayerInventoryTexture : ThaumcraftTextureInstance(
         )
     }
 }
-

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/ResearchTableInventoryTexture.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/ResearchTableInventoryTexture.kt
@@ -11,7 +11,7 @@ object ResearchTableInventoryTexture : ThaumcraftTextureInstance(
     uvScale = Scale(width = 310, height =  219)
 ) {
     val inventoryOrigin = Vector2D(x = 67, y = 191)
-    
+
     object Slots {
         val scribeToolsOrigin = Vector2D(x = 75, y = 10)
         val notesOrigin = Vector2D(x = 219, y = 10)
@@ -28,7 +28,7 @@ object ResearchTableInventoryTexture : ThaumcraftTextureInstance(
             origin = Vector2D(x = 12, y = 12),
             scale
         )
-        
+
         val rightBound = Rectangle(
             origin = Vector2D(x = 250, y = 12),
             scale
@@ -40,7 +40,7 @@ object ResearchTableInventoryTexture : ThaumcraftTextureInstance(
             origin = Vector2D(80, 35),
             scale = ParchmentTexture.scale
         )
-        val centerOrigin = bounds.origin + ParchmentTexture.centerOrigin 
+        val centerOrigin = bounds.origin + ParchmentTexture.centerOrigin
     }
 
     object CopyButton {

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/RuneTexture.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/gui/textures/RuneTexture.kt
@@ -17,9 +17,9 @@ class RuneTexture private constructor(
 
     companion object {
         val offsetToFitInHexCenter = Vector2D(3,3)
-        
+
         private val allRunes = (0..15).map(::RuneTexture)
-        
+
         fun random() = allRunes.random()
     }
 }

--- a/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/mixin/TableBlockMixin.kt
+++ b/src/main/kotlin/elan/tweaks/thaumcraft/research/frontend/integration/table/mixin/TableBlockMixin.kt
@@ -12,9 +12,7 @@ import thaumcraft.common.blocks.BlockTable
 @Mixin(BlockTable::class)
 abstract class TableBlockMixin {
 
-    private companion object {
-        private const val THAUMCRAFT_RESEARCH_TABLE_GUI_ID = 10
-    }
+    private val `tcrt$THAUMCRAFT_RESEARCH_TABLE_GUI_ID`: Int = 10
 
     @Redirect(
         method = ["onBlockActivated"],
@@ -22,7 +20,7 @@ abstract class TableBlockMixin {
         require = 4
     )
     private fun correctGuiCallFor(entityPlayer: EntityPlayer, mod: Any, modGuiId: Int, world: World, x: Int, y: Int, z: Int) {
-        return if (modGuiId == THAUMCRAFT_RESEARCH_TABLE_GUI_ID) {
+        return if (modGuiId == `tcrt$THAUMCRAFT_RESEARCH_TABLE_GUI_ID`) {
             entityPlayer.openGui(ThaumcraftResearchTweaks, ThaumcraftResearchGuiHandler.IDs.RESEARCH_TABLE, world, x, y, z)
         } else {
             entityPlayer.openGui(mod, modGuiId, world, x, y, z)

--- a/src/main/resources/spotless.gradle
+++ b/src/main/resources/spotless.gradle
@@ -1,0 +1,30 @@
+printf("Configuring spotless\n")
+
+// Spotless autoformatter
+// See https://github.com/diffplug/spotless/tree/main/plugin-gradle
+// Can be locally toggled via spotless:off/spotless:on comments
+spotless {
+    encoding 'UTF-8'
+
+    format 'misc', {
+        target '.gitignore'
+
+        trimTrailingWhitespace()
+        indentWithSpaces(4)
+        endWithNewline()
+    }
+    java {
+        toggleOffOn()
+        importOrder()
+        removeUnusedImports()
+        palantirJavaFormat('1.1.0') // last version supporting jvm 8
+    }
+    kotlin {
+        toggleOffOn()
+        ktfmt('0.39')
+
+        trimTrailingWhitespace()
+        indentWithSpaces(4)
+        endWithNewline()
+    }
+}

--- a/src/main/resources/spotless.gradle
+++ b/src/main/resources/spotless.gradle
@@ -21,7 +21,8 @@ spotless {
     }
     kotlin {
         toggleOffOn()
-        ktfmt('0.39')
+        // ktfmt('0.39')
+        // last version supporting jvm 8 is 0.12, but its dependency is missing
 
         trimTrailingWhitespace()
         indentWithSpaces(4)

--- a/src/test/kotlin/elan/tweaks/thaumcraft/research/client/gui/VectorXYTest.kt
+++ b/src/test/kotlin/elan/tweaks/thaumcraft/research/client/gui/VectorXYTest.kt
@@ -13,10 +13,10 @@ internal class VectorXYTest {
     fun `should be greater given any component of other is less then its`() {
         val points = listOf(
             Vector2D(5, 5),
-            
+
             Vector2D(5, 10),
             Vector2D(10, 5),
-            
+
             Vector2D(5, 20),
             Vector2D(20, 5),
         )
@@ -32,7 +32,7 @@ internal class VectorXYTest {
     fun `should be less given both components of other are greater or equal to its`() {
         val points = listOf(
             Vector2D(15, 15),
-            
+
             Vector2D(15, 10),
             Vector2D(10, 15),
         )
@@ -47,7 +47,7 @@ internal class VectorXYTest {
     @Test
     fun `should be equal given both components of other are equal`() {
         val other = Vector2D(10, 10)
-        
+
         assertThat(point == other).isTrue
     }
 }


### PR DESCRIPTION
This is the same concept as https://github.com/GTNewHorizons/Hodgepodge/pull/129. We have found that the inner class in `TableBlockMixin` causes a crash with any of the following coremods:
* backport5160 
* BetterFPS 
* Serene Seasons

The error is the following:
```
java.lang.NoClassDefFoundError: thaumcraft/common/blocks/BlockTable$Companion$7149d9bcd511454b9be6e6d52bff76da
```

It happens regardless of what Mixin bootstrap mod is used (I tried SpongeMixins 1.5.0, GTNHMixins 2.1.1 and GasStation 0.4.0).

This PR removes the inner class to fix the issue.